### PR TITLE
Refactor alarm panel to modern Home Assistant API (HA 2025.11+ compatibility)

### DIFF
--- a/custom_components/tc20e/alarm_control_panel.py
+++ b/custom_components/tc20e/alarm_control_panel.py
@@ -1,18 +1,14 @@
 """Alarm Control Panel for TC20E integration."""
-
 from __future__ import annotations
+
+from typing import Any
 
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_PENDING,
-)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -21,46 +17,60 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import TC20EUpdateCoordinator
 
-ALARM_STATE_TO_HA_STATE = {
-    101: STATE_ALARM_ARMED_AWAY,
-    102: STATE_ALARM_ARMED_HOME,
-    100: STATE_ALARM_DISARMED,
-    0: STATE_ALARM_PENDING,
+
+# Mapping from TC20E numeric status codes to Home Assistant alarm states.
+ALARM_STATE_MAP: dict[int, AlarmControlPanelState] = {
+    # 101 = total arm (full arm)
+    101: AlarmControlPanelState.ARMED_AWAY,
+    # 102 = partial arm (home arm)
+    102: AlarmControlPanelState.ARMED_HOME,
+    # 100 = disarmed
+    100: AlarmControlPanelState.DISARMED,
+    # 0 = pending / unknown / in progress
+    0: AlarmControlPanelState.PENDING,
 }
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up alarm panel from config entry."""
-
+    """Set up alarm panel from a config entry."""
     coordinator: TC20EUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities([TC20EAlarmPanel(coordinator)], False)
 
 
 class TC20EAlarmPanel(
-    CoordinatorEntity[TC20EUpdateCoordinator], AlarmControlPanelEntity
+    CoordinatorEntity[TC20EUpdateCoordinator],
+    AlarmControlPanelEntity,
 ):
-    """TC20E, Domonial Alarm Panel."""
+    """TC20E Domonial alarm panel."""
 
+    # Let HA use the device name instead of the entity name.
     _attr_has_entity_name = True
     _attr_name = None
 
-    def __init__(
-        self,
-        coordinator: TC20EUpdateCoordinator,
-    ) -> None:
-        """Initialize the Domonial Alarm panel."""
+    # Features supported by this alarm panel.
+    _attr_supported_features = (
+        AlarmControlPanelEntityFeature.ARM_HOME
+        | AlarmControlPanelEntityFeature.ARM_AWAY
+    )
+
+    # No code is required to arm/disarm from HA.
+    _attr_code_arm_required = False
+    _attr_code_format = None
+
+    # Static unique ID for this alarm panel instance.
+    _attr_unique_id = "domonial_alarm_panel_1"
+
+    def __init__(self, coordinator: TC20EUpdateCoordinator) -> None:
+        """Initialize the Domonial alarm panel."""
         super().__init__(coordinator)
+
         self._displayname = "Domonial"
-        self._attr_supported_features = (
-            AlarmControlPanelEntityFeature.ARM_HOME
-            | AlarmControlPanelEntityFeature.ARM_AWAY
-        )
-        self._attr_code_arm_required = False
-        self._attr_code_format = None
-        self._attr_unique_id = "domonial_alarm_panel_1"
-        self._attr_state = ALARM_STATE_TO_HA_STATE[self.coordinator.alarmstatus]
+
+        # Device information exposed in the device registry.
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, "domonial_alarm_panel_1")},
             name="Domonial Alarm Panel",
@@ -68,45 +78,60 @@ class TC20EAlarmPanel(
             manufacturer="Honeywell",
         )
 
+    #
+    # Core alarm state handling
+    #
+
     @property
-    def extra_state_attributes(self) -> dict:
-        """Additional states for alarm panel."""
+    def alarm_state(self) -> AlarmControlPanelState | None:
+        """Return the current alarm state using the AlarmControlPanelState enum."""
+        return ALARM_STATE_MAP.get(self.coordinator.alarmstatus)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes for the alarm panel."""
         return {
             "display_name": self._displayname,
         }
 
-    async def async_alarm_disarm(self, code=None) -> None:
-        """Disarm alarm."""
+    #
+    # Commands
+    #
+
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Disarm the alarm."""
         command = "disarm"
         await self.coordinator.setalarm(command)
-        if alarm_state := self.coordinator.alarmstatus:
-            self._attr_state = ALARM_STATE_TO_HA_STATE[alarm_state]
+        # Coordinator has updated alarmstatus; just push state to HA.
         self.async_write_ha_state()
 
-    async def async_alarm_arm_away(self, code=None) -> None:
-        """Arm alarm away."""
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        """Arm the alarm in away mode."""
         command = "full"
         await self.coordinator.setalarm(command)
-        if alarm_state := self.coordinator.alarmstatus:
-            self._attr_state = ALARM_STATE_TO_HA_STATE[alarm_state]
         self.async_write_ha_state()
 
-    async def async_alarm_arm_home(self, code=None) -> None:
-        """Arm alarm away."""
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Arm the alarm in home / partial mode."""
         command = "partial"
         await self.coordinator.setalarm(command)
-        if alarm_state := self.coordinator.alarmstatus:
-            self._attr_state = ALARM_STATE_TO_HA_STATE[alarm_state]
         self.async_write_ha_state()
+
+    #
+    # Coordinator callbacks
+    #
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if alarm_state := self.coordinator.alarmstatus:
-            self._attr_state = ALARM_STATE_TO_HA_STATE[alarm_state]
+        # The coordinator updated self.coordinator.alarmstatus; just notify HA.
+        self.async_write_ha_state()
         super()._handle_coordinator_update()
 
     @property
     def available(self) -> bool:
-        """Return entity available."""
+        """Return True if entity is available.
+
+        Currently always True as long as the integration is loaded.
+        """
         return True

--- a/custom_components/tc20e/manifest.json
+++ b/custom_components/tc20e/manifest.json
@@ -3,8 +3,8 @@
   "name": "Total Connect 2.0E",
   "codeowners": ["@jerhaag"],
   "config_flow": true,
-  "documentation": "https://github.com/jerhaag/TC20e",
+  "documentation": "https://github.com/jerhaag/tc20e",
   "iot_class": "cloud_polling",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "requirements": ["bs4==0.0.2"]
 }

--- a/custom_components/tc20e/translations/fr.json
+++ b/custom_components/tc20e/translations/fr.json
@@ -1,0 +1,19 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Compte déjà configuré"
+        },
+        "error": {
+            "auth_error": "Identifiant ou mot de passe incorrect",
+            "connection_error": "Echec de la connexion"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "username": "Identifiant",
+                    "password": "Mot de passe"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the tc20e integration to remain compatible with Home Assistant Core 2025.11 and newer.

Home Assistant 2025.11 removed the legacy STATE_ALARM_* constants from homeassistant.const, requiring integrations to migrate to the new AlarmControlPanelState enum and the alarm_state property.
The existing implementation relied on the deprecated constants, which caused the integration to fail at startup with an ImportError.

This PR modernizes the alarm platform accordingly and cleans up the internal state handling.

⸻

Changes included

Alarm Control Panel
	•	Removed all legacy STATE_ALARM_* imports (removed from HA Core).
	•	Introduced the new AlarmControlPanelState enum.
	•	Implemented the recommended alarm_state property (official API requirement in HA 2025.11+).
	•	Added a clean and explicit ALARM_STATE_MAP translating TC20E numeric statuses to HA alarm states.
	•	Improved entity logic and coordinator update handling.
	•	Updated code comments and structure for clarity and maintainability.
	•	Normalized entity metadata.

Manifest
	•	Bumped integration version to 0.1.3.
	•	Updated metadata for consistency.

Translation
	•	Now speaking French.


⸻

Breaking Changes
	•	This integration no longer supports Home Assistant versions older than 2025.11.
	•	Legacy alarm state constants have been fully removed.
	•	All internal state handling is now based exclusively on AlarmControlPanelState.

This aligns the integration with current Home Assistant development guidelines and avoids future deprecation issues.

⸻

Testing performed
	•	Verified successful installation via HACS using release tag v0.1.3.
	•	Confirmed entity loads without errors on Home Assistant Core 2025.12.1.
	•	Validated:
	•	alarm_state reporting
	•	Arming in Away mode
	•	Arming in Home/Partial mode
	•	Disarming
	•	Confirmed coordinator updates propagate correctly to the entity.
	•	Confirmed logs are clean and no deprecation warnings remain.

⸻

Why this PR is needed

Without this update, the integration fails to load on any system running Home Assistant 2025.11 or newer because the platform cannot import deprecated constants that no longer exist.

This PR ensures long-term compatibility with current and future Home Assistant versions.
